### PR TITLE
fix: cleaning up some inconsistent error messaging

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,7 @@ SwaggerParser.prototype.parse = async function (path, api, options, callback) {
     if (schema.swagger) {
       // Verify that the parsed object is a Swagger API
       if (schema.swagger === undefined || schema.info === undefined || schema.paths === undefined) {
-        throw ono.syntax(`${args.path || args.schema} is not a valid Swagger API definition`);
+        throw ono.syntax(`${args.path || "Supplied schema"} is not a valid Swagger API definition.`);
       }
       else if (typeof schema.swagger === "number") {
         // This is a very common mistake, so give a helpful error message
@@ -79,23 +79,23 @@ SwaggerParser.prototype.parse = async function (path, api, options, callback) {
     else {
       let supportedVersions = ["3.0.0", "3.0.1", "3.0.2", "3.0.3", "3.1.0"];
 
-      // Verify that the parsed object is a Openapi API
+      // Verify that the parsed object is an OpenAPI definition
       if (schema.openapi === undefined || schema.info === undefined) {
-        throw ono.syntax(`${args.path || args.schema} is not a valid Openapi API definition`);
+        throw ono.syntax(`${args.path || "Supplied schema"} is not a valid OpenAPI definition.`);
       }
       else if (schema.paths === undefined) {
         if (schema.openapi === "3.1.0") {
           if (schema.webhooks === undefined) {
-            throw ono.syntax(`${args.path || args.schema} is not a valid Openapi API definition`);
+            throw ono.syntax(`${args.path || "Supplied schema"} is not a valid OpenAPI definition.`);
           }
         }
         else {
-          throw ono.syntax(`${args.path || args.schema} is not a valid Openapi API definition`);
+          throw ono.syntax(`${args.path || "Supplied schema"} is not a valid OpenAPI definition.`);
         }
       }
       else if (typeof schema.openapi === "number") {
         // This is a very common mistake, so give a helpful error message
-        throw ono.syntax('Openapi version number must be a string (e.g. "3.0.0") not a number.');
+        throw ono.syntax('OpenAPI version number must be a string (e.g. "3.0.0") not a number.');
       }
       else if (typeof schema.info.version === "number") {
         // This is a very common mistake, so give a helpful error message

--- a/lib/util.js
+++ b/lib/util.js
@@ -76,4 +76,15 @@ function fixOasRelativeServers (schema, filePath) {
   }
 }
 
+/**
+ * Determine the proper name for the API specification schema used by a given schema.
+ *
+ * @param {object} schema
+ * @returns {string} - The name of the specification that this schema utilizes.
+ */
+function getSpecificationName (schema) {
+  return (schema.swagger) ? "Swagger" : "OpenAPI";
+}
+
 exports.fixOasRelativeServers = fixOasRelativeServers;
+exports.getSpecificationName = getSpecificationName;

--- a/lib/validators/schema.js
+++ b/lib/validators/schema.js
@@ -5,6 +5,7 @@ const AjvDraft4 = require("ajv-draft-04");
 const Ajv = require("ajv/dist/2020");
 const { openapi } = require("@apidevtools/openapi-schemas");
 const betterAjvErrors = require("@readme/better-ajv-errors");
+const { getSpecificationName } = require("../util");
 
 module.exports = validateSchema;
 
@@ -52,7 +53,7 @@ function validateSchema (api, options) {
   let isValid = ajv.validate(schema, api);
   if (!isValid) {
     let err = ajv.errors;
-    let message = "Swagger schema validation failed.\n";
+    let message = `${getSpecificationName(api)} schema validation failed.\n`;
     message += "\n";
     message += betterAjvErrors(schema, api, reduceAjvErrors(err), {
       colorize: options.validate.colorizeErrors,

--- a/test/specs/invalid/invalid.spec.js
+++ b/test/specs/invalid/invalid.spec.js
@@ -13,7 +13,7 @@ describe("Invalid APIs (can't be parsed)", () => {
     }
     catch (err) {
       expect(err).to.be.an.instanceOf(SyntaxError);
-      expect(err.message).to.contain("not-swagger.yaml is not a valid Openapi API definition");
+      expect(err.message).to.contain("not-swagger.yaml is not a valid OpenAPI definition");
     }
   });
 
@@ -24,7 +24,7 @@ describe("Invalid APIs (can't be parsed)", () => {
     }
     catch (err) {
       expect(err).to.be.an.instanceOf(SyntaxError);
-      expect(err.message).to.contain("no-paths-or-webhooks.yaml is not a valid Openapi API definition");
+      expect(err.message).to.contain("no-paths-or-webhooks.yaml is not a valid OpenAPI definition");
     }
   });
 

--- a/test/specs/validate-schema/invalid/invalid-security-scheme.yaml
+++ b/test/specs/validate-schema/invalid/invalid-security-scheme.yaml
@@ -1,0 +1,18 @@
+openapi: "3.0.0"
+info:
+  version: "1.0.0"
+  title: Invalid API
+
+paths:
+  /:
+    post:
+      responses:
+        200:
+          description: "OK"
+      security:
+        - tlsAuth: []
+
+components:
+  securitySchemes:
+    tlsAuth:
+      type: "mutualTLS"          # <---- mutualTLS is only available on OpenAPI 3.1

--- a/test/specs/validate-schema/validate-schema.spec.js
+++ b/test/specs/validate-schema/validate-schema.spec.js
@@ -102,6 +102,12 @@ describe("Invalid APIs (Swagger 2.0 schema validation)", () => {
       valid: false,
       file: "oneof.yaml"
     },
+    {
+      name: "invalid security sceheme for OpenAPI 3.0",
+      valid: false,
+      file: "invalid-security-scheme.yaml",
+      openapi: true,
+    },
   ];
 
   it('should pass validation if "options.validate.schema" is false', async () => {
@@ -134,7 +140,13 @@ describe("Invalid APIs (Swagger 2.0 schema validation)", () => {
         }
         catch (err) {
           expect(err).to.be.an.instanceOf(SyntaxError);
-          expect(err.message).to.match(/^Swagger schema validation failed.\n(.*)+/);
+          if (test.openapi) {
+            expect(err.message).to.match(/^OpenAPI schema validation failed.\n(.*)+/);
+          }
+          else {
+            expect(err.message).to.match(/^Swagger schema validation failed.\n(.*)+/);
+          }
+
           expect(err.details).to.be.an("array").with.length.above(0);
 
           // Make sure the Ajv error details object is valid


### PR DESCRIPTION
## 🧰 Changes

* [x] Updates errors that read "Openapi API definition" to now be "OpenAPI definition".
* [x] Updates error messages that included a supplied JS object that rendered out as "[Object object] is not a valid Openapi API definition" to now be "Supplied definition is not a valid OpenAPI definition."
* [x] Schema validation errors are now contextual to what type of schema is being validated so invalid OpenAPI definitions no longer say "Swagger validation failed".
* [x] Added periods to error messages that didn't have one.

