### PR TITLE
test: ignoring an unvalidating ayden.com spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ node_modules
 # Test output
 /.nyc_output
 /coverage
+debug.js
 
 # Jekyll output
 _site

--- a/.npmignore
+++ b/.npmignore
@@ -5,4 +5,5 @@ coverage/
 .eslint*
 .mocha*
 .nyc*
+debug.js
 karma.*.js

--- a/test/specs/real-world/known-errors.js
+++ b/test/specs/real-world/known-errors.js
@@ -73,6 +73,12 @@ function getKnownApiErrors () {
       whatToDo: "ignore"
     },
 
+    {
+      api: "adyen.com:CheckoutService",
+      error: "unevaluatedProperties must NOT have unevaluated properties",
+      whatToDo: "ignore"
+    },
+
     // Cloudmersive.com's API definition contains invalid JSON Schema types
     {
       api: "cloudmersive.com:ocr",

--- a/test/specs/real-world/known-errors.js
+++ b/test/specs/real-world/known-errors.js
@@ -78,6 +78,21 @@ function getKnownApiErrors () {
       error: "unevaluatedProperties must NOT have unevaluated properties",
       whatToDo: "ignore"
     },
+    {
+      api: "adyen.com:PaymentService",
+      error: "unevaluatedProperties must NOT have unevaluated properties",
+      whatToDo: "ignore"
+    },
+    {
+      api: "adyen.com:PayoutService",
+      error: "unevaluatedProperties must NOT have unevaluated properties",
+      whatToDo: "ignore"
+    },
+    {
+      api: "adyen.com:RecurringService",
+      error: "unevaluatedProperties must NOT have unevaluated properties",
+      whatToDo: "ignore"
+    },
 
     // Cloudmersive.com's API definition contains invalid JSON Schema types
     {


### PR DESCRIPTION
Spec currently is shipping with a `source` property at the root level.