### PR TITLE
fix: using a proper fork of @apidevtools/json-schema-ref-parser

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,13 @@
 /* eslint-disable no-unused-vars */
 const validateSchema = require('./validators/schema');
 const validateSpec = require('./validators/spec');
-const normalizeArgs = require('@apidevtools/json-schema-ref-parser/lib/normalize-args');
+const normalizeArgs = require('@readme/json-schema-ref-parser/lib/normalize-args');
 const util = require('./util');
 const Options = require('./options');
 const maybe = require('call-me-maybe');
 const { ono } = require('@jsdevtools/ono');
-const $RefParser = require('@apidevtools/json-schema-ref-parser');
-const dereference = require('@apidevtools/json-schema-ref-parser/lib/dereference');
+const $RefParser = require('@readme/json-schema-ref-parser');
+const dereference = require('@readme/json-schema-ref-parser/lib/dereference');
 
 module.exports = OpenAPIParser;
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,4 +1,4 @@
-const $RefParserOptions = require('@apidevtools/json-schema-ref-parser/lib/options');
+const $RefParserOptions = require('@readme/json-schema-ref-parser/lib/options');
 const schemaValidator = require('./validators/schema');
 const specValidator = require('./validators/spec');
 const util = require('./util');

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line unicorn/import-style
 const util = require('util');
-const url = require('@apidevtools/json-schema-ref-parser/lib/util/url');
+const url = require('@readme/json-schema-ref-parser/lib/util/url');
 
 exports.format = util.format;
 exports.inherits = util.inherits;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "github:erunion/json-schema-ref-parser#fix/dates-as-strings",
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
         "@readme/better-ajv-errors": "^1.1.0",
+        "@readme/json-schema-ref-parser": "^1.0.0",
         "ajv": "^8.6.3",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.1"
@@ -42,33 +42,6 @@
       },
       "peerDependencies": {
         "openapi-types": ">=7"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "0.0.0-dev",
-      "resolved": "git+ssh://git@github.com/erunion/json-schema-ref-parser.git#402904c92c8465db788be70655c3773c6e42a051",
-      "license": "MIT",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@apidevtools/openapi-schemas": {
@@ -2258,6 +2231,33 @@
       "peerDependencies": {
         "eslint": "^8.0.0",
         "prettier": "^2.0.2"
+      }
+    },
+    "node_modules/@readme/json-schema-ref-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
+      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@readme/json-schema-ref-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/@readme/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -16388,31 +16388,6 @@
     }
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": {
-      "version": "git+ssh://git@github.com/erunion/json-schema-ref-parser.git#402904c92c8465db788be70655c3773c6e42a051",
-      "from": "@apidevtools/json-schema-ref-parser@github:erunion/json-schema-ref-parser#fix/dates-as-strings",
-      "requires": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        }
-      }
-    },
     "@apidevtools/openapi-schemas": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
@@ -18263,6 +18238,32 @@
         "eslint-plugin-testing-library": "^5.0.0",
         "eslint-plugin-unicorn": "^38.0.0",
         "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0"
+      }
+    },
+    "@readme/json-schema-ref-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
+      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
+      "requires": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        }
       }
     },
     "@sindresorhus/is": {

--- a/package.json
+++ b/package.json
@@ -70,11 +70,11 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": "github:erunion/json-schema-ref-parser#fix/dates-as-strings",
     "@apidevtools/openapi-schemas": "^2.1.0",
     "@apidevtools/swagger-methods": "^3.0.2",
     "@jsdevtools/ono": "^7.1.3",
     "@readme/better-ajv-errors": "^1.1.0",
+    "@readme/json-schema-ref-parser": "^1.0.0",
     "ajv": "^8.6.3",
     "ajv-draft-04": "^1.0.0",
     "call-me-maybe": "^1.0.1"

--- a/test/specs/oas-relative-servers/v3-relative-servers.spec.js
+++ b/test/specs/oas-relative-servers/v3-relative-servers.spec.js
@@ -1,7 +1,7 @@
 const OpenAPIParser = require('../../../lib');
 const { expect } = require('chai');
 const path = require('../../utils/path');
-const $RefParser = require('@apidevtools/json-schema-ref-parser');
+const $RefParser = require('@readme/json-schema-ref-parser');
 const sinon = require('sinon');
 
 // Import of our fixed OpenAPI JSON files


### PR DESCRIPTION
## 🧰 Changes

Because of the way that we were loading in my personal fix against `@apidevtools/json-schema-ref-parser`, on environments that didn't have Git installed the install of this package may fail because it was being loaded over git+ssh. To resolve this I've instead moved my fix over to a new fork under our org (https://github.com/readmeio/json-schema-ref-parser/) and published that to npm (https://npm.im/@readme/json-schema-ref-parser).

This fix is in support of https://github.com/readmeio/rdme/issues/401.

## 🧬 QA & Testing

If all tests still pass then this is good to go.