### PR TITLE
fix: updating openapi spec validation to also know about headers `content`

### DIFF
--- a/lib/validators/spec/openapi.js
+++ b/lib/validators/spec/openapi.js
@@ -219,7 +219,15 @@ function validateResponse(code, response, responseId) {
     const header = response.headers[headerName];
     const headerId = `${responseId}/headers/${headerName}`;
 
-    validateSchema(header.schema, headerId);
+    if (header.schema) {
+      validateSchema(header.schema, headerId);
+    } else if (header.content) {
+      Object.keys(header.content).forEach(mediaType => {
+        if (header.content[mediaType].schema) {
+          validateSchema(header.content[mediaType].schema || {}, `${headerId}/content/${mediaType}/schema`);
+        }
+      });
+    }
   });
 
   if (response.content) {

--- a/test/specs/validate-spec/invalid/3.x/array-response-header-content-no-items.yaml
+++ b/test/specs/validate-spec/invalid/3.x/array-response-header-content-no-items.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.0
+info:
+  version: "1.0.0"
+  title: Invalid API
+
+paths:
+  /users:
+    get:
+      responses:
+        "default":
+          description: hello world
+          headers:
+            Content-Type:
+              schema:
+                type: string
+            Last-Modified:
+              content:
+                application/json:
+                  schema:
+                    type: array

--- a/test/specs/validate-spec/validate-spec.spec.js
+++ b/test/specs/validate-spec/validate-spec.spec.js
@@ -227,6 +227,15 @@ describe('Invalid APIs (specification validation)', () => {
         'Validation failed. /paths/users/get/responses/default/headers/Last-Modified is an array, so it must include an "items" schema'
       );
     });
+
+    describe('should also catch the same within `content`', () => {
+      it('OpenAPI 3.x', () => {
+        return assertInvalid(
+          '3.x/array-response-header-content-no-items.yaml',
+          'Validation failed. /paths/users/get/responses/default/headers/Last-Modified/content/application/json/schema is an array, so it must include an "items" schema'
+        );
+      });
+    });
   });
 
   describe("should catch if a required property in an input doesn't exist", () => {


### PR DESCRIPTION
## 🧰 Changes

This updates the bespoke spec validation code for OAS definitions that when we check if a response header schema is invalid to also not assume that `schema` is present because headers can have `content` like parameters.

## 🧬 QA & Testing

See test.