### PR TITLE
feat: surfacing all schema validation errors

### DIFF
--- a/lib/validators/schema.js
+++ b/lib/validators/schema.js
@@ -67,7 +67,7 @@ function validateSchema(api, options) {
  */
 function initializeAjv(draft04 = true) {
   const opts = {
-    allErrors: false,
+    allErrors: true,
     strict: false,
     validateFormats: false,
   };

--- a/test/specs/validate-schema/invalid/multiple-invalid-properties.yaml
+++ b/test/specs/validate-schema/invalid/multiple-invalid-properties.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.0
+info:
+  description: 'This is a sample server Petstore server.'
+  version: 1.0.0
+  title: Swagger Petstore
+servers:
+  - urll: http://petstore.swagger.io/v2
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+paths:
+  '/pet/findByStatus':
+    get:
+      tagss:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - available
+                - pending
+                - sold
+              default: available
+      responses:
+        '200':
+          description: OK

--- a/test/specs/validate-schema/validate-schema.spec.js
+++ b/test/specs/validate-schema/validate-schema.spec.js
@@ -3,7 +3,7 @@ const { expect } = require('chai');
 const OpenAPIParser = require('../../..');
 const path = require('../../utils/path');
 
-describe('Invalid APIs (Swagger 2.0 schema validation)', () => {
+describe('Invalid APIs (Swagger 2.0 and OpenAPI 3.x schema validation)', () => {
   const tests = [
     {
       name: 'invalid response code',
@@ -103,7 +103,7 @@ describe('Invalid APIs (Swagger 2.0 schema validation)', () => {
       file: 'oneof.yaml',
     },
     {
-      name: 'invalid security sceheme for OpenAPI 3.0',
+      name: 'invalid security scheme for OpenAPI 3.0',
       valid: false,
       file: 'invalid-security-scheme.yaml',
       openapi: true,
@@ -118,6 +118,23 @@ describe('Invalid APIs (Swagger 2.0 schema validation)', () => {
       validate: { schema: false },
     });
     expect(api).to.be.an('object');
+  });
+
+  it('should return all errors', async () => {
+    try {
+      await OpenAPIParser.validate(path.rel('specs/validate-schema/invalid/multiple-invalid-properties.yaml'));
+      throw new Error('Validation should have failed, but it succeeded!');
+    } catch (err) {
+      expect(err).to.be.an.instanceOf(SyntaxError);
+      expect(err.message).to.match(/^OpenAPI schema validation failed.\n(.*)+/);
+
+      expect(err.details).to.be.an('array').to.have.length(3);
+
+      expect(err.message).to.contain("REQUIRED must have required property 'url'");
+      expect(err.message).to.contain('url is missing here');
+      expect(err.message).to.contain('ADDITIONAL PROPERTY must NOT have additional properties');
+      expect(err.message).to.contain('tagss is not expected to be here');
+    }
   });
 
   for (const test of tests) {


### PR DESCRIPTION
## 🧰 Changes

This resolves an issue brought up in https://github.com/readmeio/rdme/issues/638 where we aren't surfacing all AJV errors when we run schema validation.