### PR TITLE
feat: expose the total amount of validation schema errors

### DIFF
--- a/lib/validators/schema.js
+++ b/lib/validators/schema.js
@@ -68,6 +68,7 @@ function validateSchema(api, options) {
 
     let additionalErrors = 0;
     let reducedErrors = reduceAjvErrors(err);
+    const totalErrors = reducedErrors.length;
     if (reducedErrors.length >= LARGE_SPEC_ERROR_CAP) {
       try {
         if (JSON.stringify(api).length >= LARGE_SPEC_SIZE_CAP) {
@@ -92,7 +93,7 @@ function validateSchema(api, options) {
       message += `Plus an additional ${additionalErrors} errors. Please resolve the above and re-run validation to see more.`;
     }
 
-    throw ono.syntax(err, { details: err }, message);
+    throw ono.syntax(err, { details: err, totalErrors }, message);
   }
 }
 

--- a/test/specs/validate-schema/validate-schema.spec.js
+++ b/test/specs/validate-schema/validate-schema.spec.js
@@ -162,7 +162,7 @@ describe('Invalid APIs (Swagger 2.0 and OpenAPI 3.x schema validation)', () => {
           }
 
           expect(err.details).to.be.an('array').with.length.above(0);
-          expect(err.totalErrors).to.be.greater.than(0);
+          expect(err.totalErrors).to.be.at.least(1);
 
           // Make sure the Ajv error details object is valid
           const details = err.details[0];

--- a/test/specs/validate-schema/validate-schema.spec.js
+++ b/test/specs/validate-schema/validate-schema.spec.js
@@ -129,6 +129,7 @@ describe('Invalid APIs (Swagger 2.0 and OpenAPI 3.x schema validation)', () => {
       expect(err.message).to.match(/^OpenAPI schema validation failed.\n(.*)+/);
 
       expect(err.details).to.be.an('array').to.have.length(3);
+      expect(err.totalErrors).to.equal(3);
 
       expect(err.message).to.contain("REQUIRED must have required property 'url'");
       expect(err.message).to.contain('url is missing here');
@@ -161,6 +162,7 @@ describe('Invalid APIs (Swagger 2.0 and OpenAPI 3.x schema validation)', () => {
           }
 
           expect(err.details).to.be.an('array').with.length.above(0);
+          expect(err.totalErrors).to.equal(err.details.length);
 
           // Make sure the Ajv error details object is valid
           const details = err.details[0];

--- a/test/specs/validate-schema/validate-schema.spec.js
+++ b/test/specs/validate-schema/validate-schema.spec.js
@@ -162,7 +162,7 @@ describe('Invalid APIs (Swagger 2.0 and OpenAPI 3.x schema validation)', () => {
           }
 
           expect(err.details).to.be.an('array').with.length.above(0);
-          expect(err.totalErrors).to.equal(err.details.length);
+          expect(err.totalErrors).to.be.greater.than(0);
 
           // Make sure the Ajv error details object is valid
           const details = err.details[0];

--- a/test/specs/validate-schema/validate-schema.spec.js
+++ b/test/specs/validate-schema/validate-schema.spec.js
@@ -129,7 +129,7 @@ describe('Invalid APIs (Swagger 2.0 and OpenAPI 3.x schema validation)', () => {
       expect(err.message).to.match(/^OpenAPI schema validation failed.\n(.*)+/);
 
       expect(err.details).to.be.an('array').to.have.length(3);
-      expect(err.totalErrors).to.equal(3);
+      expect(err.totalErrors).to.equal(2);
 
       expect(err.message).to.contain("REQUIRED must have required property 'url'");
       expect(err.message).to.contain('url is missing here');


### PR DESCRIPTION
## 🧰 Changes

It would be very nice if we exposed the _total_ amount of schema validation errors that occurred so this adds that value to a `totalErrors` property on the `Error` object that's thrown.