### PR TITLE
feat: Bug in server variable validation in 3.1

### DIFF
--- a/test/specs/validate-spec/valid/3.1/component-schema-with-hyphens.yaml
+++ b/test/specs/validate-spec/valid/3.1/component-schema-with-hyphens.yaml
@@ -2,6 +2,15 @@ openapi: 3.1.0
 info:
   version: "1.0"
   title: Invalid API
+servers:
+  - url: https://someurl.org/{xxx}
+    variables:
+      xxx:
+        enum:
+          - a
+          - b
+        description: xxx path param for the server url
+        default: a
 paths:
   /anything:
     get:


### PR DESCRIPTION
Validation for server variables isn't working as expected.

The description field should be allowed.

```
  1) Invalid APIs (specification validation)
       components / definitions
         should allow a component schema name that contains hyphens
           OpenAPI 3.1:
     SyntaxError: OpenAPI schema validation failed.

UNEVALUATED PROPERTY must NOT have unevaluated properties

  14 |             "b"
  15 |           ],
> 16 |           "description": "xxx path param for the server url",
     |           ^^^^^^^^^^^^^ 😲  description is not expected to be here!
  17 |           "default": "a"
  18 |         }
  19 |       }
      at validateSchema (lib/validators/schema.js:96:15)
      at OpenAPIParser.validate (lib/index.js:160:7)
```

I am not familiar with the codebase. Hopefully this is easy to fix.

@erunion any ideas?