### PR TITLE
ci: run less real world definitions in CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "call-me-maybe": "^1.0.1"
       },
       "devDependencies": {
-        "@jsdevtools/host-environment": "^2.1.2",
         "@readme/eslint-config": "^14.0.0",
         "@types/node": "^20.12.7",
         "@vitest/coverage-v8": "^1.6.0",
@@ -791,15 +790,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@jsdevtools/host-environment": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/host-environment/-/host-environment-2.1.2.tgz",
-      "integrity": "sha512-9T+w9lWwMExriyAXafL12lPHxOaF7PwSbyf6nCZDpidrXb5r+SiCs6YjsAEOHHdFj7spvNVzEFVT23fDsPbf5Q==",
-      "dev": true,
-      "dependencies": {
-        "@qawolf/ci-info": "^2.1.0"
-      }
-    },
     "node_modules/@jsdevtools/ono": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
@@ -851,12 +841,6 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
-    },
-    "node_modules/@qawolf/ci-info": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@qawolf/ci-info/-/ci-info-2.1.0.tgz",
-      "integrity": "sha512-D5H5RjqqE+YxI2oeTgSRuIjdy/hli90H5mMd81bBrYlOfB/f4TBsKMoaWfzI5E4bmFzLfQJuvvepTaWrxVfBug==",
-      "dev": true
     },
     "node_modules/@readme/better-ajv-errors": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "test": "vitest run --coverage"
   },
   "devDependencies": {
-    "@jsdevtools/host-environment": "^2.1.2",
     "@readme/eslint-config": "^14.0.0",
     "@types/node": "^20.12.7",
     "@vitest/coverage-v8": "^1.6.0",

--- a/test/specs/real-world/real-world.test.ts
+++ b/test/specs/real-world/real-world.test.ts
@@ -1,4 +1,3 @@
-import { host } from '@jsdevtools/host-environment';
 import { describe, it } from 'vitest';
 
 import OpenAPIParser from '../../..';
@@ -6,7 +5,7 @@ import realWorldAPIs from '../../fixtures/real-world-apis.json';
 
 import { isKnownError } from './known-errors';
 
-const MAX_APIS_TO_TEST = host.ci ? 1500 : 100;
+const MAX_APIS_TO_TEST = 100;
 
 describe(
   'Real-world APIs',


### PR DESCRIPTION
## 🧰 Changes

Running tests on every real world API definition from apis.guru takes forever and because we have pretty solid test coverage already we can just let that be a manual process if/when we do want to run tests on them all.