### PR TITLE
feat: supporting OpenAPI 3.0.4 and 3.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,9 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node:
-          - 18
-          - 20
+          - lts/-1
+          - lts/*
+          - latest
 
     steps:
       - name: Checkout source
@@ -36,7 +37,3 @@ jobs:
 
       - name: Run tests
         run: npm run test --ignore-scripts
-        env:
-          # `chalk` has troubles with color detection while on CI and also in how it's used within our tests.
-          # https://github.com/chalk/supports-color/issues/106
-          FORCE_COLOR: 1

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,10 @@ const util = require('./util');
 const validateSchema = require('./validators/schema');
 const validateSpec = require('./validators/spec');
 
+const supported31Versions = ['3.1.0', '3.1.1'];
+const supported30Versions = ['3.0.0', '3.0.1', '3.0.2', '3.0.3', '3.0.4'];
+const supportedVersions = [...supported31Versions, ...supported30Versions];
+
 module.exports = OpenAPIParser;
 
 /**
@@ -72,13 +76,11 @@ OpenAPIParser.prototype.parse = async function (path, api, options, callback) {
         throw ono.syntax(`Unrecognized Swagger version: ${schema.swagger}. Expected 2.0`);
       }
     } else {
-      const supportedVersions = ['3.0.0', '3.0.1', '3.0.2', '3.0.3', '3.1.0'];
-
       // Verify that the parsed object is an OpenAPI definition
       if (schema.openapi === undefined || schema.info === undefined) {
         throw ono.syntax(`${args.path || 'Supplied schema'} is not a valid OpenAPI definition.`);
       } else if (schema.paths === undefined) {
-        if (schema.openapi === '3.1.0') {
+        if (supported31Versions.includes(schema.openapi)) {
           if (schema.webhooks === undefined) {
             throw ono.syntax(`${args.path || 'Supplied schema'} is not a valid OpenAPI definition.`);
           }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -3,6 +3,13 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    env: {
+      // Vitest strips colors from content by default and `chalk` has troubles with color detection
+      // in CI.
+      // https://github.com/chalk/supports-color/issues/106
+      FORCE_COLOR: '1',
+    },
+
     exclude: [
       '**/node_modules/**',
       '**/dist/**',


### PR DESCRIPTION
## 🧰 Changes

This adds support for validating OpenAPI 3.0.4 and 3.1.1 definitions.