### PR TITLE
chore(deps): upgrading `better-ajv-errors`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
-        "@readme/better-ajv-errors": "^2.0.0",
+        "@readme/better-ajv-errors": "^2.1.2",
         "@readme/json-schema-ref-parser": "^1.2.0",
         "@readme/openapi-schemas": "^3.1.0",
         "ajv": "^8.12.0",
@@ -929,17 +929,17 @@
       }
     },
     "node_modules/@readme/better-ajv-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-2.0.0.tgz",
-      "integrity": "sha512-RquGi4rLHJNBIdlp+28x3a0T1m3NTbDMkAIAxE+u0pVEF2cBGSyfwbNT77lRWqKveOod0ua3MW5S+czTR3cExw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-2.1.2.tgz",
+      "integrity": "sha512-nfAs1+wzO9SWwji/7mbhXo2vJZ6PLMSpv7XNrFrwufhdwRPc07GNBwcEsiL6qq8VnI+A2lMEkcj7xCEK1nOrNQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/code-frame": "^7.22.5",
         "@babel/runtime": "^7.22.5",
         "@humanwhocodes/momoa": "^2.0.3",
-        "chalk": "^4.1.2",
         "jsonpointer": "^5.0.0",
-        "leven": "^3.1.0"
+        "leven": "^3.1.0",
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=18"
@@ -2493,6 +2493,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2508,6 +2509,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2522,6 +2524,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2532,7 +2535,8 @@
     "node_modules/chalk/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/check-error": {
       "version": "2.1.1",
@@ -4578,6 +4582,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6706,6 +6711,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@apidevtools/swagger-methods": "^3.0.2",
     "@jsdevtools/ono": "^7.1.3",
-    "@readme/better-ajv-errors": "^2.0.0",
+    "@readme/better-ajv-errors": "^2.1.2",
     "@readme/json-schema-ref-parser": "^1.2.0",
     "@readme/openapi-schemas": "^3.1.0",
     "ajv": "^8.12.0",


### PR DESCRIPTION
## 🧰 Changes

This bumps `@readme/better-ajv-errors` to swap out its usage of [chalk](https://npm.im/chalk) for [picocolors](https://npm.im/picocolors) for error message colorization.