### PR TITLE
chore: dependency maintenance + removing dead code

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -3,7 +3,6 @@ const util = require('util');
 
 const url = require('@readme/json-schema-ref-parser/lib/util/url');
 
-exports.format = util.format;
 exports.inherits = util.inherits;
 
 /**

--- a/lib/validators/spec/openapi.js
+++ b/lib/validators/spec/openapi.js
@@ -1,7 +1,11 @@
-const swaggerMethods = require('@apidevtools/swagger-methods');
 const { ono } = require('@jsdevtools/ono');
 
 const util = require('../../util');
+
+/**
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#path-item-object}
+ */
+const supportedHTTPMethods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
 
 module.exports = validateSpec;
 
@@ -58,8 +62,7 @@ function validateSpec(api) {
  * @param {string}        operationIds  - An array of collected operationIds found in other paths
  */
 function validatePath(api, path, pathId, operationIds) {
-  // `@apidevtools/swagger-methods` doesn't ship a `trace` method so we need to improvise.
-  [...swaggerMethods, 'trace'].forEach(operationName => {
+  supportedHTTPMethods.forEach(operationName => {
     const operation = path[operationName];
     const operationId = `${pathId}/${operationName}`;
 

--- a/lib/validators/spec/swagger.js
+++ b/lib/validators/spec/swagger.js
@@ -1,7 +1,11 @@
-const swaggerMethods = require('@apidevtools/swagger-methods');
 const { ono } = require('@jsdevtools/ono');
 
 const util = require('../../util');
+
+/**
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#path-item-object}
+ */
+const supportedHTTPMethods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch'];
 
 const primitiveTypes = ['array', 'boolean', 'integer', 'number', 'string'];
 const schemaTypes = ['array', 'boolean', 'integer', 'number', 'string', 'object', 'null', undefined];
@@ -47,7 +51,7 @@ function validateSpec(api) {
  * @param {string}        operationIds  - An array of collected operationIds found in other paths
  */
 function validatePath(api, path, pathId, operationIds) {
-  swaggerMethods.forEach(operationName => {
+  supportedHTTPMethods.forEach(operationName => {
     const operation = path[operationName];
     const operationId = `${pathId}/${operationName}`;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.7.0",
       "license": "MIT",
       "dependencies": {
-        "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
         "@readme/better-ajv-errors": "^2.1.2",
         "@readme/json-schema-ref-parser": "^1.2.0",
@@ -57,11 +56,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/@apidevtools/swagger-methods": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
-      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.24.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@readme/eslint-config": "^14.1.2",
-        "@types/node": "^22.10.10",
+        "@types/node": "^22.12.0",
         "@vitest/coverage-v8": "^3.0.4",
         "eslint": "^8.56.0",
         "openapi-types": "^12.1.3",
@@ -1535,9 +1535,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.10.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.10.tgz",
-      "integrity": "sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==",
+      "version": "22.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.12.0.tgz",
+      "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@readme/eslint-config": "^14.1.2",
-    "@types/node": "^22.10.10",
+    "@types/node": "^22.12.0",
     "@vitest/coverage-v8": "^3.0.4",
     "eslint": "^8.56.0",
     "openapi-types": "^12.1.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
-    "@apidevtools/swagger-methods": "^3.0.2",
     "@jsdevtools/ono": "^7.1.3",
     "@readme/better-ajv-errors": "^2.1.2",
     "@readme/json-schema-ref-parser": "^1.2.0",


### PR DESCRIPTION
## 🧰 Changes

* [x] Drops `@apidevtools/swagger-mehtods` in favor of a hardcoded list of HTTP methods. This list never changes so there's really no need to pull in a separate library for it.
* [x] Removing a `node:util.format` export that was never being used.