### PR TITLE
chore: dropping `sinon` for native vitest spies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "eslint": "^8.56.0",
         "openapi-types": "^12.1.3",
         "prettier": "^3.1.1",
-        "sinon": "^19.0.2",
         "typescript": "^5.7.3",
         "vitest": "^3.0.4"
       },
@@ -1472,50 +1471,6 @@
         "win32"
       ]
     },
-    "node_modules/@sinonjs/commons": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
-      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.2.tgz",
-      "integrity": "sha512-4Bb+oqXZTSTZ1q27Izly9lv8B9dlV61CROxPiVtywwzv5SnytJqhvYe6FclHYuXml4cd1VHPo1zd5PmTeJozvA==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1"
-      }
-    },
-    "node_modules/@sinonjs/samsam": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
-      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "lodash.get": "^4.4.2",
-        "type-detect": "^4.1.0"
-      }
-    },
-    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@sinonjs/text-encoding": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
-      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
-      "dev": true
-    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -2773,15 +2728,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/dir-glob": {
@@ -5292,12 +5238,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/just-extend": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
-      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
-      "dev": true
-    },
     "node_modules/kebab-case": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.1.tgz",
@@ -5362,12 +5302,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "node_modules/lodash.merge": {
@@ -5537,19 +5471,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
-    },
-    "node_modules/nise": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
-      "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "^13.0.1",
-        "@sinonjs/text-encoding": "^0.7.3",
-        "just-extend": "^6.2.0",
-        "path-to-regexp": "^8.1.0"
-      }
     },
     "node_modules/node-releases": {
       "version": "2.0.18",
@@ -5851,15 +5772,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/path-type": {
@@ -6402,24 +6314,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/sinon": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
-      "integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "^13.0.2",
-        "@sinonjs/samsam": "^8.0.1",
-        "diff": "^7.0.0",
-        "nise": "^6.1.1",
-        "supports-color": "^7.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/sinon"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -6933,15 +6827,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "eslint": "^8.56.0",
     "openapi-types": "^12.1.3",
     "prettier": "^3.1.1",
-    "sinon": "^19.0.2",
     "typescript": "^5.7.3",
     "vitest": "^3.0.4"
   },

--- a/test/specs/oas-relative-servers/v3-relative-servers.test.ts
+++ b/test/specs/oas-relative-servers/v3-relative-servers.test.ts
@@ -1,6 +1,7 @@
+import type { MockInstance } from 'vitest';
+
 import $RefParser from '@readme/json-schema-ref-parser';
-import sinon from 'sinon';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import OpenAPIParser from '../../../lib';
 import path from '../../utils/path';
@@ -17,32 +18,26 @@ const RELATIVE_SERVERS_OAS3_URL_1 = 'https://petstore3.swagger.io/api/v3/openapi
 const RELATIVE_SERVERS_OAS3_URL_2 = 'https://foo.my.cloud/v1/petstore/relativeservers';
 
 describe('Servers with relative paths in OpenAPI v3 files', () => {
-  let mockParse;
+  let spy: MockInstance<typeof $RefParser.prototype.parse>;
 
   beforeEach(() => {
-    // Mock the parse function
-    mockParse = sinon.stub($RefParser.prototype, 'parse');
+    spy = vi.spyOn($RefParser.prototype, 'parse');
   });
 
   afterEach(() => {
-    // Restore the parse function
-    $RefParser.prototype.parse.restore();
+    vi.restoreAllMocks();
   });
 
   it('should fix relative servers path in the file fetched from url', async () => {
-    mockParse.callsFake(() => {
-      // to prevent edit of the original JSON
-      return JSON.parse(JSON.stringify(v3RelativeServerJson));
-    });
+    spy.mockImplementationOnce(() => JSON.parse(JSON.stringify(v3RelativeServerJson)));
+
     const apiJson = await OpenAPIParser.parse(RELATIVE_SERVERS_OAS3_URL_1);
     expect(apiJson.servers[0].url).to.equal('https://petstore3.swagger.io/api/v3');
   });
 
   it('should fix relative servers at root, path and operations level in the file fetched from url', async () => {
-    mockParse.callsFake(() => {
-      // to prevent edit of the original JSON
-      return JSON.parse(JSON.stringify(v3RelativeServerPathsOpsJson));
-    });
+    spy.mockImplementationOnce(() => JSON.parse(JSON.stringify(v3RelativeServerPathsOpsJson)));
+
     const apiJson = await OpenAPIParser.parse(RELATIVE_SERVERS_OAS3_URL_2);
     expect(apiJson.servers[0].url).to.equal('https://foo.my.cloud/api/v3');
     expect(apiJson.paths['/pet'].servers[0].url).to.equal('https://foo.my.cloud/api/v4');
@@ -50,9 +45,8 @@ describe('Servers with relative paths in OpenAPI v3 files', () => {
   });
 
   it('should parse but no change to relative servers path in local file import', async () => {
-    mockParse.callsFake(() => {
-      return JSON.parse(JSON.stringify(v3RelativeServerPathsOpsJson));
-    });
+    spy.mockImplementationOnce(() => JSON.parse(JSON.stringify(v3RelativeServerPathsOpsJson)));
+
     const apiJson = await OpenAPIParser.parse(path.rel('./v3-relative-server.json'));
     expect(apiJson.servers[0].url).to.equal('/api/v3');
     expect(apiJson.paths['/pet'].servers[0].url).to.equal('/api/v4');
@@ -60,9 +54,8 @@ describe('Servers with relative paths in OpenAPI v3 files', () => {
   });
 
   it('should parse but no change to non-relative servers path in local file import', async () => {
-    mockParse.callsFake(() => {
-      return JSON.parse(JSON.stringify(v3NonRelativeServerJson));
-    });
+    spy.mockImplementationOnce(() => JSON.parse(JSON.stringify(v3NonRelativeServerJson)));
+
     const apiJson = await OpenAPIParser.parse(path.rel('./v3-non-relative-server.json'));
     expect(apiJson.servers[0].url).to.equal('https://petstore3.swagger.com/api/v3');
     expect(apiJson.paths['/pet'].servers[0].url).to.equal('https://petstore3.swagger.com/api/v4');


### PR DESCRIPTION
## 🧰 Changes

This drops our unit test dependency on `sinon` in favor of native Vitest spies.
